### PR TITLE
fix: introduce tolerance parameter when checking images for physical …

### DIFF
--- a/petpal/utils/useful_functions.py
+++ b/petpal/utils/useful_functions.py
@@ -280,7 +280,8 @@ def read_plasma_glucose_concentration(file_path: str, correction_scale: float = 
 
 
 def check_physical_space_for_ants_image_pair(image_1: ants.core.ANTsImage,
-                                             image_2: ants.core.ANTsImage) -> bool:
+                                             image_2: ants.core.ANTsImage,
+                                             tolerance: float=1e-2) -> bool:
     """
     Determines whether two ANTs images share the same physical space. This function works
     when comparing 4D-images with 3D-images, as opposed to
@@ -293,6 +294,8 @@ def check_physical_space_for_ants_image_pair(image_1: ants.core.ANTsImage,
     Args:
         image_1 (ants.core.ANTsImage): The first ANTs image for comparison.
         image_2 (ants.core.ANTsImage): The second ANTs image for comparison.
+        tolerance (float): Absolute tolerance for differences between components of the affine
+            transform matrix for the two images. Default 0.01.
 
     Returns:
         bool: `True` if both images share the same physical space, `False` otherwise.
@@ -300,9 +303,9 @@ def check_physical_space_for_ants_image_pair(image_1: ants.core.ANTsImage,
     """
 
 
-    dir_cons = np.allclose(image_1.direction[:3,:3], image_2.direction[:3,:3])
-    spc_cons = np.allclose(image_1.spacing[:3], image_2.spacing[:3])
-    org_cons = np.allclose(image_1.origin[:3], image_2.origin[:3])
+    dir_cons = np.allclose(image_1.direction[:3,:3], image_2.direction[:3,:3],atol=tolerance)
+    spc_cons = np.allclose(image_1.spacing[:3], image_2.spacing[:3],atol=tolerance)
+    org_cons = np.allclose(image_1.origin[:3], image_2.origin[:3],atol=tolerance)
 
     return dir_cons and spc_cons and org_cons
 


### PR DESCRIPTION
…space consistency

Necessary as the default tolerance for np.allclose is greater than the uncertainty introduced by ants image read on the values of the affine matrix